### PR TITLE
[Runner]: Log full output when test.cob is missing

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -45,7 +45,7 @@ else
     # In some cases, the test output might be overly verbose, in which case stripping
     # the unneeded information can be very helpful to the student
     printf "${test_output}" | grep "COMPILE AND RUN TEST" 2>&1 1>/dev/null
-    if [ $? -eq 0 ]; then
+    if [ -f ${solution_dir}/test.cob ] && [ $? -eq 0 ]; then
         sanitized_test_output=$(printf "${test_output}" | sed '1,/^COMPILE AND RUN TEST$/d' | sed '/warning: ignoring redundant \. \[-Wothers\]/ d' | sed '/test.cob: in paragraph .\(UT-BEFORE-EACH\|UT-AFTER-EACH\|UT-LOOKUP-FILE\|UT-BEFORE\)./ d' )
     else
         sanitized_test_output="${test_output} $(printf " \nSOMETHING WENT WRONG DURING TEST SETUP, PLEASE OPEN A TICKET AT: https://github.com/exercism/cobol/issues/new")"


### PR DESCRIPTION
Cobolcheck is not producing an output and the logs are filtered.
This PR skips the filtering in case the `test.cob` is missing.

Signed-off-by: Sven Pfennig <s.pfennig@reply.de>