### PR TITLE
[Runner]: Install gnuCobol 3.1.2 on ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ RUN /bin/fetch-cobolcheck
 FROM ubuntu:20.04
 
 # TODO: install packages required to run the tests
-RUN apt-get update && apt-get install -y \
-    jq \
-    gnucobol \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get -y install jq curl tar libncurses5-dev libgmp-dev libdb-dev ranger autoconf build-essential && \
+    curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.1/gnucobol-3.1.2.tar.gz | tar xz && \
+    cd gnucobol-3.1.2 && ./configure --prefix=/usr &&  make &&  make install && ldconfig && cd /tmp/ && rm -rf ./* && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=download /bin/cobolcheck /bin/cobolcheck
 


### PR DESCRIPTION
@KTSnowy, this installs gnuCobol version 3.1.2.