### PR TITLE
upgrade to GnuCOBOL 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ FROM ubuntu:20.04
 # TODO: install packages required to run the tests
 RUN apt-get update && \
     apt-get -y install jq curl tar libncurses5-dev libgmp-dev libdb-dev ranger autoconf build-essential && \
-    curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.1/gnucobol-3.1.2.tar.gz | tar xz && \
-    cd gnucobol-3.1.2 && ./configure --prefix=/usr &&  make &&  make install && ldconfig && cd /tmp/ && rm -rf ./* && \
+    curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.2/gnucobol-3.2.tar.gz | tar xz && \
+    cd gnucobol-3.2 && ./configure --prefix=/usr &&  make &&  make install && ldconfig && cd /tmp/ && rm -rf ./* && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=download /bin/cobolcheck /bin/cobolcheck

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "test.cob:1: error: PROGRAM-ID header missing"
+  "message": "test.cob:1: error: PROGRAM-ID header missing\n    1 > <EOF>"
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "test.cob:133: error: invalid indicator 's' at column 7"
+  "message": "test.cob:133: error: invalid indicator 's' at column 7\n  131 | ..\n  132 |       * CCHECKWS.CPY END..\n  133 >       s not cobol syntax!!!..\n  134 |        PROCEDURE DIVISION...\n  135 |            PERFORM UT-INITIALIZE.."
 }


### PR DESCRIPTION
A student notified me of the fact that the documentation says `B-OR` but the current compiler doesn't take without complaint. 3.2 has been out for a while and is stable.