### PR TITLE
Bump and pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM alpine AS download
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS download
 COPY bin/fetch-cobolcheck /bin/
 RUN apk add --no-cache curl coreutils bash
 WORKDIR /bin/
 RUN /bin/fetch-cobolcheck 
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 # TODO: install packages required to run the tests
+ENV export COB_LD_FLAGS='-Wl, --no-as-needed'
 RUN apt-get update && \
     apt-get -y install jq curl tar libncurses5-dev libgmp-dev libdb-dev ranger autoconf build-essential && \
     curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.2/gnucobol-3.2.tar.gz | tar xz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,30 @@
-FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS download
-COPY bin/fetch-cobolcheck /bin/
-RUN apk add --no-cache curl coreutils bash
-WORKDIR /bin/
-RUN /bin/fetch-cobolcheck 
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS base
 
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
-
-# TODO: install packages required to run the tests
-ENV export COB_LD_FLAGS='-Wl, --no-as-needed'
+# Update the OS, fetch build requirements.
 RUN apt-get update && \
-    apt-get -y install jq curl tar libncurses5-dev libgmp-dev libdb-dev ranger autoconf build-essential && \
-    curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.2/gnucobol-3.2.tar.gz | tar xz && \
-    cd gnucobol-3.2 && ./configure --prefix=/usr &&  make &&  make install && ldconfig && cd /tmp/ && rm -rf ./* && \
+    apt-get --yes --no-install-recommends install \
+        autoconf build-essential ca-certificates curl jq \
+        libdb-dev libgmp-dev libncurses5-dev ranger tar && \
     rm -rf /var/lib/apt/lists/*
 
+# Fetch cobolcheck
+FROM base AS download
+WORKDIR /bin/
+COPY bin/fetch-cobolcheck /bin/
+RUN /bin/fetch-cobolcheck
+
+# Set up the runner
+FROM base
 COPY --from=download /bin/cobolcheck /bin/cobolcheck
 
+# Build gnucobol
+WORKDIR /tmp/gnucobol_build
+ENV export COB_LD_FLAGS='-Wl, --no-as-needed'
+RUN curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.2/gnucobol-3.2.tar.gz | tar xz && \
+    cd gnucobol-3.2 && ./configure --prefix=/usr && make && make install && ldconfig && \
+    cd /tmp/ && rm -rf /tmp/gnucobol_build
+
+# Set up the test runner environment.
 WORKDIR /opt/test-runner
 COPY . .
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.